### PR TITLE
fix(architect): aggregate structural metrics in snapshot to prevent hallucination

### DIFF
--- a/internal/agent/architect.go
+++ b/internal/agent/architect.go
@@ -134,6 +134,7 @@ func (pc *ProjectContext) FormatForLLM(maxTokensHint int) string {
 	formatHotspots(&b, snap)
 	formatCouplingPairs(&b, snap)
 	formatTopObservations(&b, snap)
+	formatStructuralMetrics(&b, snap)
 	formatQualitativeContext(&b, pc, maxChars)
 
 	return b.String()
@@ -280,6 +281,21 @@ func formatTopObservations(b *strings.Builder, snap *ArchSnapshot) {
 	for _, o := range obs[:limit] {
 		fmt.Fprintf(b, "- %s: %d\n", o.name, o.count)
 	}
+	b.WriteString("\n")
+}
+
+func formatStructuralMetrics(b *strings.Builder, snap *ArchSnapshot) {
+	s := snap.Metrics.Structural
+	b.WriteString("## Structural Metrics (aggregated from all units)\n")
+	b.WriteString("| Metric | Total | Description |\n")
+	b.WriteString("|--------|------:|-------------|\n")
+	fmt.Fprintf(b, "| panic_calls | %d | panic() calls in production code |\n", s.PanicCalls)
+	fmt.Fprintf(b, "| os_exit_calls | %d | os.Exit() calls (1 in main is normal) |\n", s.OsExitCalls)
+	fmt.Fprintf(b, "| global_mutable_count | %d | Package-level mutable var declarations |\n", s.GlobalMutableCount)
+	fmt.Fprintf(b, "| defer_in_loop | %d | defer statements inside for/range loops |\n", s.DeferInLoop)
+	fmt.Fprintf(b, "| init_func_count | %d | Files containing init() functions |\n", s.InitFuncCount)
+	fmt.Fprintf(b, "| context_not_first | %d | Functions with context.Context not as first param |\n", s.ContextNotFirst)
+	fmt.Fprintf(b, "| errors_ignored | %d | Error returns assigned to blank identifier |\n", s.ErrorsIgnored)
 	b.WriteString("\n")
 }
 

--- a/internal/agent/architect_prompts.go
+++ b/internal/agent/architect_prompts.go
@@ -59,11 +59,26 @@ Respond with JSON:
 
 const architectPhase4SystemPrompt = `You are assessing the security posture and operational readiness of a software project. You have the architecture snapshot with structural metrics.
 
-Reference relevant metrics from the snapshot: global_mutable_count, panic_calls, os_exit_calls, init_func observations. Look for:
-- Security concerns (global mutable state, unsafe patterns)
+Reference the "Structural Metrics (aggregated from all units)" table in the snapshot.
+These are EXACT counts computed from AST analysis — use them as-is, do not estimate or infer.
+If a metric shows 0, report it as a positive finding (e.g., "zero panic calls — good practice").
+
+Analyze these structural metrics:
+- panic_calls: Count of panic() in production code (should be 0 per Go best practices)
+- os_exit_calls: Count of os.Exit() calls (1 in main.go is normal)
+- global_mutable_count: Package-level mutable var declarations (potential race conditions)
+- defer_in_loop: Defer statements inside for/range loops (resource leak risk)
+- errors_ignored: Error returns assigned to blank identifier (swallowed errors)
+- init_func_count: Files with init() functions (hidden initialization)
+- context_not_first: Functions with context.Context not as first parameter
+
+Also assess:
 - Configuration management (hardcoded values, environment handling)
 - Operational readiness (error handling, graceful degradation, logging)
 - Dependency management (external dependency surface)
+
+IMPORTANT: Only cite metrics that appear in the data above. If a metric is not present
+in the snapshot, do not reference it. Never fabricate specific numeric values.
 
 Respond with JSON:
 {
@@ -102,7 +117,8 @@ Rules:
 - You MUST ground every projection in the data
 - If you can't project a number, say "unknown" — do NOT fabricate
 - Every recommendation must have at least one delta
-- Reference specific package names and metrics from the snapshot`
+- Reference specific package names and metrics from the snapshot
+- Use exact values from the "Structural Metrics" table — do not invent counts`
 
 const architectPhase6SystemPrompt = `You are producing the final synthesis of an architectural review. You have all prior phase outputs including the architecture snapshot, analysis findings, and comparative recommendations.
 

--- a/internal/agent/architect_snapshot.go
+++ b/internal/agent/architect_snapshot.go
@@ -49,12 +49,26 @@ type CouplingPair struct {
 
 // SnapshotMetrics holds aggregate metrics across all packages.
 type SnapshotMetrics struct {
-	TotalUnits        int            `json:"total_units"`
-	TotalPackages     int            `json:"total_packages"`
-	AvgScore          float64        `json:"avg_score"`
-	GradeDistribution map[string]int `json:"grade_distribution"`
-	TopObservations   map[string]int `json:"top_observations"`
-	PolicyViolations  map[string]int `json:"policy_violations"`
+	TotalUnits        int                  `json:"total_units"`
+	TotalPackages     int                  `json:"total_packages"`
+	AvgScore          float64              `json:"avg_score"`
+	GradeDistribution map[string]int       `json:"grade_distribution"`
+	TopObservations   map[string]int       `json:"top_observations"`
+	PolicyViolations  map[string]int       `json:"policy_violations"`
+	Structural        StructuralAggregates `json:"structural"`
+}
+
+// StructuralAggregates holds summed structural metrics across all units.
+// These are computed from Evidence.Metrics in certification records, providing
+// the LLM with real data instead of requiring it to guess.
+type StructuralAggregates struct {
+	PanicCalls         int `json:"panic_calls"`
+	OsExitCalls        int `json:"os_exit_calls"`
+	GlobalMutableCount int `json:"global_mutable_count"`
+	DeferInLoop        int `json:"defer_in_loop"`
+	InitFuncCount      int `json:"init_func_count"`
+	ContextNotFirst    int `json:"context_not_first"`
+	ErrorsIgnored      int `json:"errors_ignored"`
 }
 
 // BuildSnapshot computes a deterministic architecture snapshot from certification records.
@@ -104,6 +118,24 @@ func BuildSnapshot(records []domain.CertificationRecord, root string) *ArchSnaps
 
 		snap.Metrics.GradeDistribution[r.Grade.String()]++
 		totalScore += r.Score
+
+		// Aggregate structural metrics from evidence
+		for _, ev := range r.Evidence {
+			if ev.Kind != domain.EvidenceKindStructural {
+				continue
+			}
+			snap.Metrics.Structural.PanicCalls += int(ev.Metrics["panic_calls"])
+			snap.Metrics.Structural.OsExitCalls += int(ev.Metrics["os_exit_calls"])
+			snap.Metrics.Structural.GlobalMutableCount += int(ev.Metrics["global_mutable_count"])
+			snap.Metrics.Structural.DeferInLoop += int(ev.Metrics["defer_in_loop"])
+			snap.Metrics.Structural.ErrorsIgnored += int(ev.Metrics["errors_ignored"])
+			if ev.Metrics["has_init_func"] > 0 {
+				snap.Metrics.Structural.InitFuncCount++
+			}
+			if ev.Metrics["context_not_first"] > 0 {
+				snap.Metrics.Structural.ContextNotFirst++
+			}
+		}
 	}
 
 	snap.Metrics.TotalUnits = len(records)

--- a/internal/agent/architect_snapshot_test.go
+++ b/internal/agent/architect_snapshot_test.go
@@ -25,6 +25,155 @@ func makeRecord(unitID string, score float64, observations []string) domain.Cert
 	}
 }
 
+func makeRecordWithEvidence(unitID string, score float64, evidence ...domain.Evidence) domain.CertificationRecord {
+	r := makeRecord(unitID, score, nil)
+	r.Evidence = evidence
+	return r
+}
+
+func TestBuildSnapshot_StructuralMetrics(t *testing.T) {
+	records := []domain.CertificationRecord{
+		makeRecordWithEvidence("go://pkg/a.go#Foo", 0.85, domain.Evidence{
+			Kind:   domain.EvidenceKindStructural,
+			Source: "structural",
+			Passed: true,
+			Metrics: map[string]float64{
+				"panic_calls":          0,
+				"os_exit_calls":        1,
+				"global_mutable_count": 3,
+				"defer_in_loop":        2,
+				"has_init_func":        1,
+				"context_not_first":    0,
+				"errors_ignored":       1,
+			},
+		}),
+		makeRecordWithEvidence("go://pkg/b.go#Bar", 0.80, domain.Evidence{
+			Kind:   domain.EvidenceKindStructural,
+			Source: "structural",
+			Passed: true,
+			Metrics: map[string]float64{
+				"panic_calls":          2,
+				"os_exit_calls":        0,
+				"global_mutable_count": 1,
+				"defer_in_loop":        0,
+				"has_init_func":        0,
+				"context_not_first":    1,
+				"errors_ignored":       3,
+			},
+		}),
+		// Record with no structural evidence — should not affect aggregates
+		makeRecord("go://pkg/c.go#Baz", 0.90, nil),
+	}
+
+	snap := agent.BuildSnapshot(records, "")
+
+	s := snap.Metrics.Structural
+	if s.PanicCalls != 2 {
+		t.Errorf("expected 2 panic_calls, got %d", s.PanicCalls)
+	}
+	if s.OsExitCalls != 1 {
+		t.Errorf("expected 1 os_exit_calls, got %d", s.OsExitCalls)
+	}
+	if s.GlobalMutableCount != 4 {
+		t.Errorf("expected 4 global_mutable_count, got %d", s.GlobalMutableCount)
+	}
+	if s.DeferInLoop != 2 {
+		t.Errorf("expected 2 defer_in_loop, got %d", s.DeferInLoop)
+	}
+	if s.InitFuncCount != 1 {
+		t.Errorf("expected 1 init_func_count, got %d", s.InitFuncCount)
+	}
+	if s.ContextNotFirst != 1 {
+		t.Errorf("expected 1 context_not_first, got %d", s.ContextNotFirst)
+	}
+	if s.ErrorsIgnored != 4 {
+		t.Errorf("expected 4 errors_ignored, got %d", s.ErrorsIgnored)
+	}
+}
+
+func TestBuildSnapshot_StructuralMetrics_AllZero(t *testing.T) {
+	records := []domain.CertificationRecord{
+		makeRecordWithEvidence("go://pkg/a.go#Foo", 0.90, domain.Evidence{
+			Kind:   domain.EvidenceKindStructural,
+			Source: "structural",
+			Passed: true,
+			Metrics: map[string]float64{
+				"panic_calls":          0,
+				"os_exit_calls":        0,
+				"global_mutable_count": 0,
+			},
+		}),
+	}
+
+	snap := agent.BuildSnapshot(records, "")
+	s := snap.Metrics.Structural
+
+	if s.PanicCalls != 0 {
+		t.Errorf("expected 0 panic_calls, got %d", s.PanicCalls)
+	}
+	if s.OsExitCalls != 0 {
+		t.Errorf("expected 0 os_exit_calls, got %d", s.OsExitCalls)
+	}
+}
+
+func TestBuildSnapshot_StructuralMetrics_IgnoresNonStructuralEvidence(t *testing.T) {
+	records := []domain.CertificationRecord{
+		makeRecordWithEvidence("go://pkg/a.go#Foo", 0.85,
+			// Lint evidence — should be ignored by structural aggregation
+			domain.Evidence{
+				Kind:    domain.EvidenceKindLint,
+				Source:  "golangci-lint",
+				Passed:  true,
+				Metrics: map[string]float64{"lint_errors": 3},
+			},
+			// Structural evidence — should be aggregated
+			domain.Evidence{
+				Kind:   domain.EvidenceKindStructural,
+				Source: "structural",
+				Passed: true,
+				Metrics: map[string]float64{
+					"panic_calls":   1,
+					"os_exit_calls": 0,
+				},
+			},
+		),
+	}
+
+	snap := agent.BuildSnapshot(records, "")
+	s := snap.Metrics.Structural
+	if s.PanicCalls != 1 {
+		t.Errorf("expected 1 panic_calls, got %d", s.PanicCalls)
+	}
+	if s.OsExitCalls != 0 {
+		t.Errorf("expected 0 os_exit_calls, got %d", s.OsExitCalls)
+	}
+}
+
+func TestBuildSnapshot_StructuralMetrics_PartialMetricsMap(t *testing.T) {
+	// Evidence with only some metrics keys present — missing keys should default to 0
+	records := []domain.CertificationRecord{
+		makeRecordWithEvidence("go://pkg/a.go#Foo", 0.85, domain.Evidence{
+			Kind:    domain.EvidenceKindStructural,
+			Source:  "structural",
+			Passed:  true,
+			Metrics: map[string]float64{"panic_calls": 5},
+		}),
+	}
+
+	snap := agent.BuildSnapshot(records, "")
+	s := snap.Metrics.Structural
+	if s.PanicCalls != 5 {
+		t.Errorf("expected 5 panic_calls, got %d", s.PanicCalls)
+	}
+	// Keys not present in evidence should remain 0
+	if s.OsExitCalls != 0 {
+		t.Errorf("expected 0 os_exit_calls for missing key, got %d", s.OsExitCalls)
+	}
+	if s.GlobalMutableCount != 0 {
+		t.Errorf("expected 0 global_mutable_count for missing key, got %d", s.GlobalMutableCount)
+	}
+}
+
 func TestBuildSnapshot(t *testing.T) {
 	records := []domain.CertificationRecord{
 		makeRecord("go://internal/engine/scorer.go#Score", 0.85, []string{"errors_ignored: 2"}),

--- a/internal/agent/architect_test.go
+++ b/internal/agent/architect_test.go
@@ -129,6 +129,46 @@ func TestFormatForLLM_SnapshotTables(t *testing.T) {
 	}
 }
 
+func TestFormatForLLM_StructuralMetrics(t *testing.T) {
+	records := []domain.CertificationRecord{
+		makeRecordWithEvidence("go://pkg/a.go#Foo", 0.85, domain.Evidence{
+			Kind:   domain.EvidenceKindStructural,
+			Source: "structural",
+			Passed: true,
+			Metrics: map[string]float64{
+				"panic_calls":          0,
+				"os_exit_calls":        1,
+				"global_mutable_count": 5,
+				"defer_in_loop":        3,
+			},
+		}),
+	}
+
+	snap := agent.BuildSnapshot(records, "")
+	pc := &agent.ProjectContext{
+		RepoName: "test-repo",
+		Snapshot: snap,
+	}
+
+	output := pc.FormatForLLM(4000)
+
+	if !strings.Contains(output, "Structural Metrics") {
+		t.Error("output should contain Structural Metrics section")
+	}
+	if !strings.Contains(output, "| panic_calls | 0 |") {
+		t.Error("output should show panic_calls with exact count 0")
+	}
+	if !strings.Contains(output, "| os_exit_calls | 1 |") {
+		t.Error("output should show os_exit_calls with exact count 1")
+	}
+	if !strings.Contains(output, "| global_mutable_count | 5 |") {
+		t.Error("output should show global_mutable_count with exact count 5")
+	}
+	if !strings.Contains(output, "| defer_in_loop | 3 |") {
+		t.Error("output should show defer_in_loop with exact count 3")
+	}
+}
+
 func TestFormatForLLM_Empty(t *testing.T) {
 	pc := &agent.ProjectContext{
 		Snapshot: agent.BuildSnapshot(nil, ""),


### PR DESCRIPTION
## Problem

Phase 4 (Security & Operations) prompt instructs the LLM:

> "Reference relevant metrics from the snapshot: `global_mutable_count`, `panic_calls`, `os_exit_calls`, `init_func` observations."

But these per-unit structural metrics are **never aggregated into the `ArchSnapshot`**. The snapshot only contains package-level scores, observation counts, and observation type strings. The LLM is told to reference data that does not exist in its context, so it hallucinates values.

### Evidence

Tested against a Go project with **0 `panic()` calls** across 2,797 units (verified by grepping source and confirming every unit report shows `panic_calls: 0`):

| Model | Claimed panic_calls | Actual | Behavior |
|-------|-------------------|--------|----------|
| Qwen3-Coder-30b | 23 | **0** | Fabricated specific number |
| Claude 3.7 Sonnet | "high" | **0** | Used vague qualifier |

### Root Cause

```
structural.go          → Evidence.Metrics (panic_calls: 0, ...)     ✅ collected
CertificationRecord    → Evidence[] with metrics                     ✅ stored
BuildSnapshot()        → ArchSnapshot.Metrics                        ❌ not aggregated
FormatForLLM()         → Text for LLM                               ❌ not rendered
Phase 4 prompt         → "Reference panic_calls..."                  ❌ asks for missing data
LLM                    → Hallucinates                                💥
```

## Solution

1. **`StructuralAggregates` in `SnapshotMetrics`** — sums `panic_calls`, `os_exit_calls`, `global_mutable_count`, `defer_in_loop`, `init_func_count`, `context_not_first`, `errors_ignored` from `Evidence.Metrics` across all records

2. **`formatStructuralMetrics()`** — renders aggregated data as a table in `FormatForLLM()` output:
   ```
   ## Structural Metrics (aggregated from all units)
   | Metric | Total | Description |
   |--------|------:|-------------|
   | panic_calls | 0 | panic() calls in production code |
   | os_exit_calls | 1 | os.Exit() calls (1 in main is normal) |
   ...
   ```

3. **Updated Phase 4 prompt** — references the actual table, includes anti-hallucination grounding:
   > "These are EXACT counts computed from AST analysis — use them as-is, do not estimate or infer. If a metric shows 0, report it as a positive finding."

4. **Phase 5 grounding** — added rule: "Use exact values from the Structural Metrics table — do not invent counts"

## Tests

- `TestBuildSnapshot_StructuralMetrics` — verifies aggregation with mixed values
- `TestBuildSnapshot_StructuralMetrics_AllZero` — verifies zero case
- `TestFormatForLLM_StructuralMetrics` — verifies output contains exact counts

All 16 packages pass, `go vet` clean.

Fixes #19